### PR TITLE
major optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+node_modules


### PR DESCRIPTION
Major changes:
- Split primalityTest() into two methods: one optimized for integers / numbers below Number.MAX_SAFE_INTEGER and one optimized for larger numbers saved as BigInts (which is a bit slower than the integer method). The appropriate method primalityTestBigint() or primalityTestNumber() is called by primalityTest(). The small number method uses a deterministic version of Miller-Rabin, while the BigInt method uses a probabilistic version. In total, primalityTest() is deterministic and a lot faster now for numbers below Number.MAX_SAFE_INTEGER.
- The Montgommery complex is only used for numbers larger than 10^30. Below it, classic Miller-Rabin is used.
- Removed asynchronous return values in order to measure speeds more accurately. Might be added back later.